### PR TITLE
Fix tabs order, avoid appearance of tab header on next row

### DIFF
--- a/js/bootstrap-tabdrop.js
+++ b/js/bootstrap-tabdrop.js
@@ -50,12 +50,6 @@
 		}
 	}());
 
-	function updateSelection(e) {
-		this.element.find('li').removeClass('active');
-		$(e.currentTarget).addClass('active');
-		this.layout();
-	}
-
 	var TabDrop = function (element, options) {
 		this.element = $(element);
 		this.options = options;
@@ -66,14 +60,13 @@
 		}
 
 		var boundLayout = $.proxy(this.layout, this);
-		var boundUpdateSelection = $.proxy(updateSelection, this);
 
 		WinResizer.register(boundLayout);
-		this.element.on('click', 'li:not(.tabdrop)', boundUpdateSelection);
+		this.element.on('click', 'li:not(.tabdrop)', boundLayout);
 
 		this.teardown = function () {
 			WinResizer.unregister(boundLayout);
-			this.element.off('click', 'li:not(.tabdrop)', boundUpdateSelection);
+			this.element.off('click', 'li:not(.tabdrop)', boundLayout);
 		};
 
 		this.layout();


### PR DESCRIPTION
### Fixing appearance of tab header on next row by rechecking offsets.

Scenario: tab headers are pushed to tabdrop but one of the pushed tabs have `.active` class which updates the title of the `li.tabdrop.active`. That results in undesirable push of the last visible tab header down to next row. This commit fixes that by rechecking offsets. Also incorrect tab order is [fixed](https://github.com/pribilinskiy/bootstrap-tabdrop/commit/04e583be5b93ea710df75cc08250644a6441243e#diff-27f32a73e621d797e5ebd2f408b54862R116).
